### PR TITLE
replaced `.pop(key)` with `.pop(key, None)` to get rid of `KeyError`s

### DIFF
--- a/djangoevents/tests/test_unifiedtranscoder.py
+++ b/djangoevents/tests/test_unifiedtranscoder.py
@@ -28,7 +28,7 @@ def test_serialize_and_deserialize_1():
     # test deserialize
     created_copy = transcoder.deserialize(created_stored_event)
     assert 'metadata' not in created_copy.__dict__
-    created.__dict__.pop('metadata')  # metadata is not included in deserialization
+    created.__dict__.pop('metadata', None)  # metadata is not included in deserialization
     assert created.__dict__ == created_copy.__dict__
 
 
@@ -49,6 +49,5 @@ def test_serialize_and_deserialize_2():
     # test deserialize
     updated_copy = transcoder.deserialize(updated_stored_event)
     assert 'metadata' not in updated_copy.__dict__
-    updated.__dict__.pop('metadata') # metadata is not included in deserialization
+    updated.__dict__.pop('metadata', None)  # metadata is not included in deserialization
     assert updated.__dict__ == updated_copy.__dict__
-

--- a/djangoevents/unifiedtranscoder.py
+++ b/djangoevents/unifiedtranscoder.py
@@ -29,10 +29,10 @@ class UnifiedTranscoder(AbstractTranscoder):
         assert isinstance(domain_event, DomainEvent)
 
         event_data = domain_event.__dict__.copy()
-        event_data.pop('domain_event_id')
-        event_data.pop('entity_id')
-        event_data.pop('entity_version')
-        event_data.pop('metadata')
+        event_data.pop('domain_event_id', None)
+        event_data.pop('entity_id', None)
+        event_data.pop('entity_version', None)
+        event_data.pop('metadata', None)
 
         domain_event_class = type(domain_event)
 
@@ -119,5 +119,3 @@ class UnifiedTranscoder(AbstractTranscoder):
 
 class ResolveDomainFailed(Exception):
     pass
-
-


### PR DESCRIPTION
I'm updating to use `djangoevents` and I have many events with no `metadata`. It causes crashes at the `djangoevents` level because the library expects these keys to be there. My patch changes the logic from "remove key" to "remove key if it exists".