### PR TITLE
made `DomainEvent.metadata` optional during serialization

### DIFF
--- a/djangoevents/tests/test_unifiedtranscoder.py
+++ b/djangoevents/tests/test_unifiedtranscoder.py
@@ -52,3 +52,11 @@ def test_serialize_and_deserialize_2():
     updated.__dict__.pop('metadata') # metadata is not included in deserialization
     assert updated.__dict__ == updated_copy.__dict__
 
+def test_metadata_is_optional():
+    transcoder = UnifiedTranscoder(json_encoder_cls=DjangoJSONEncoder)
+    created = SampleAggregate.Created(entity_id='b089a0a6-e0b3-480d-9382-c47f99103b3d')
+
+    try:
+        transcoder.serialize(created)
+    except AttributeError:
+        assert False, 'Serialization of an event without metadata should not raise an exception.'

--- a/djangoevents/tests/test_unifiedtranscoder.py
+++ b/djangoevents/tests/test_unifiedtranscoder.py
@@ -1,3 +1,4 @@
+import pytest
 from ..unifiedtranscoder import UnifiedTranscoder
 from eventsourcing.domain.model.entity import EventSourcedEntity
 from django.core.serializers.json import DjangoJSONEncoder
@@ -59,4 +60,4 @@ def test_metadata_is_optional():
     try:
         transcoder.serialize(created)
     except AttributeError:
-        assert False, 'Serialization of an event without metadata should not raise an exception.'
+        pytest.fail('Serialization of an event without metadata should not raise an exception.')

--- a/djangoevents/unifiedtranscoder.py
+++ b/djangoevents/unifiedtranscoder.py
@@ -45,7 +45,7 @@ class UnifiedTranscoder(AbstractTranscoder):
             aggregate_type=self._get_aggregate_type(domain_event),
             aggregate_version=domain_event.entity_version,
             create_date=datetime.fromtimestamp(timestamp_from_uuid(domain_event.domain_event_id)),
-            metadata=self._json_encode(domain_event.metadata),
+            metadata=self._json_encode(getattr(domain_event, 'metadata', None)),
             module_name=domain_event_class.__module__,
             class_name=domain_event_class.__qualname__,
             # have to have stored_entity_id because of the lib


### PR DESCRIPTION
In the project I'm working on most events have no metadata.