### PR TITLE
Switched to adding `schema_version` to event objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+0.13.1
+======
+
+- Switched to adding `schema_version` to event objects themselves
+  instead of just transcoded events. This way events will pass
+  validation if their Avro schemas require `schema_version`.
+
+- Renamed setting responsible for the above feature
+  from `EVENT_TRANSCODER.ADDS_EVENT_VERSION_TO_DATA`
+  to `ADDS_SCHEMA_VERSION_TO_EVENT_DATA`.
+
+
 0.13.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -217,9 +217,7 @@ For compatibility with some systems, we provide an option to add event version t
 ```python
 DJANGOEVENTS_CONFIG = {
     ...
-    'EVENT_TRANSCODER': {
-        'ADDS_EVENT_VERSION_TO_DATA': True,
-    },
+    'ADDS_SCHEMA_VERSION_TO_EVENT_DATA': True,
     ...
 }
 ```

--- a/djangoevents/apps.py
+++ b/djangoevents/apps.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.utils.module_loading import import_module
 from djangoevents import DomainEvent
 from .exceptions import EventSchemaError
-from .settings import transcoder_adds_event_version_to_data
+from .settings import adds_schema_version_to_event_data
 from .schema import get_event_version
 from .schema import load_all_event_schemas
 import os.path
@@ -75,7 +75,7 @@ def patch_domain_event():
     def new_init(self, *args, **kwargs):
         old_init(self, *args, **kwargs)
 
-        if transcoder_adds_event_version_to_data():
+        if adds_schema_version_to_event_data():
             self.__dict__['schema_version'] = get_event_version(cls)
 
     cls.__init__ = new_init

--- a/djangoevents/apps.py
+++ b/djangoevents/apps.py
@@ -69,13 +69,12 @@ def patch_domain_event():
     Patch `DomainEvent` to add `schema_version` to event payload.
     """
 
-    cls = DomainEvent
-    old_init = cls.__init__
+    old_init = DomainEvent.__init__
 
     def new_init(self, *args, **kwargs):
         old_init(self, *args, **kwargs)
 
         if adds_schema_version_to_event_data():
-            self.__dict__['schema_version'] = get_event_version(cls)
+            self.__dict__['schema_version'] = get_event_version(self.__class__)
 
-    cls.__init__ = new_init
+    DomainEvent.__init__ = new_init

--- a/djangoevents/apps.py
+++ b/djangoevents/apps.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.utils.module_loading import import_module
 from djangoevents import DomainEvent
 from .exceptions import EventSchemaError
+from .settings import transcoder_adds_event_version_to_data
 from .schema import get_event_version
 from .schema import load_all_event_schemas
 import os.path
@@ -74,7 +75,7 @@ def patch_domain_event():
     def new_init(self, *args, **kwargs):
         old_init(self, *args, **kwargs)
 
-        if False:
+        if transcoder_adds_event_version_to_data():
             self.__dict__['schema_version'] = get_event_version(cls)
 
     cls.__init__ = new_init

--- a/djangoevents/settings.py
+++ b/djangoevents/settings.py
@@ -8,9 +8,7 @@ _DEFAULTS = {
         'ENABLED': False,
         'SCHEMA_DIR': 'avro',
     },
-    'EVENT_TRANSCODER': {
-        'ADDS_EVENT_VERSION_TO_DATA': False,
-    },
+    'ADDS_SCHEMA_VERSION_TO_EVENT_DATA': False,
 }
 
 
@@ -39,6 +37,6 @@ def get_avro_dir():
     return avro_dir
 
 
-def transcoder_adds_event_version_to_data():
+def adds_schema_version_to_event_data():
     config = get_config()
-    return config.get('EVENT_TRANSCODER', {}).get('ADDS_EVENT_VERSION_TO_DATA', False)
+    return config.get('ADDS_SCHEMA_VERSION_TO_EVENT_DATA', False)

--- a/djangoevents/tests/test_domain.py
+++ b/djangoevents/tests/test_domain.py
@@ -2,6 +2,7 @@ from ..domain import BaseEntity, DomainEvent
 from ..schema import get_event_version
 from ..schema import set_event_version
 from django.test import override_settings
+from unittest import mock
 
 import os
 import pytest
@@ -105,12 +106,7 @@ def test_events_have_schema_version_when_enabled():
     'ADDS_SCHEMA_VERSION_TO_EVENT_DATA': True,
 })
 def test_events_have_correct_schema_version():
-    original_version = getattr(SampleEntity.Created, 'version', None)
-    expected_version = 666
 
-    try:
-        SampleEntity.Created.version = expected_version
+    with mock.patch.object(SampleEntity.Created, 'version', 666):
         event = SampleEntity.Created(entity_id=1)
-        assert event.schema_version == expected_version
-    finally:
-        SampleEntity.Created.version = original_version
+        assert event.schema_version == 666

--- a/djangoevents/tests/test_domain.py
+++ b/djangoevents/tests/test_domain.py
@@ -79,3 +79,23 @@ def test_version_4(tmpdir):
         set_event_version(SampleEntity, SampleEntity.Created, avro_dir=avro_dir.strpath)
 
         assert get_event_version(SampleEntity.Created) == version
+
+
+@override_settings(DJANGOEVENTS_CONFIG={
+    'EVENT_TRANSCODER': {
+        'ADDS_EVENT_VERSION_TO_DATA': False,
+    },
+})
+def test_events_dont_have_schema_version_when_disabled():
+    event = SampleEntity.Created(entity_id=1)
+    assert not hasattr(event, 'schema_version')
+
+
+@override_settings(DJANGOEVENTS_CONFIG={
+    'EVENT_TRANSCODER': {
+        'ADDS_EVENT_VERSION_TO_DATA': True,
+    },
+})
+def test_events_have_schema_version_when_enabled():
+    event = SampleEntity.Created(entity_id=1)
+    assert event.schema_version == 1

--- a/djangoevents/tests/test_domain.py
+++ b/djangoevents/tests/test_domain.py
@@ -82,9 +82,7 @@ def test_version_4(tmpdir):
 
 
 @override_settings(DJANGOEVENTS_CONFIG={
-    'EVENT_TRANSCODER': {
-        'ADDS_EVENT_VERSION_TO_DATA': False,
-    },
+    'ADDS_SCHEMA_VERSION_TO_EVENT_DATA': False,
 })
 def test_events_dont_have_schema_version_when_disabled():
     event = SampleEntity.Created(entity_id=1)
@@ -92,9 +90,7 @@ def test_events_dont_have_schema_version_when_disabled():
 
 
 @override_settings(DJANGOEVENTS_CONFIG={
-    'EVENT_TRANSCODER': {
-        'ADDS_EVENT_VERSION_TO_DATA': True,
-    },
+    'ADDS_SCHEMA_VERSION_TO_EVENT_DATA': True,
 })
 def test_events_have_schema_version_when_enabled():
     event = SampleEntity.Created(entity_id=1)

--- a/djangoevents/tests/test_unifiedtranscoder.py
+++ b/djangoevents/tests/test_unifiedtranscoder.py
@@ -57,11 +57,16 @@ def test_serialize_and_deserialize_2():
     assert updated.__dict__ == updated_copy.__dict__
 
 
-def test_serializer_can_add_event_version_to_data():
+@override_settings(DJANGOEVENTS_CONFIG={
+    'EVENT_TRANSCODER': {
+        'ADDS_EVENT_VERSION_TO_DATA': False,
+    },
+})
+def test_serializer_doesnt_include_schema_version_when_its_disabled():
     transcoder = UnifiedTranscoder(json_encoder_cls=DjangoJSONEncoder)
     event = SampleAggregate.Created(entity_id='b089a0a6-e0b3-480d-9382-c47f99103b3d', attr1='val1', attr2='val2')
     serialized_event = transcoder.serialize(event)
-    assert serialized_event.event_data == '{"attr1":"val1","attr2":"val2","schema_version":1}'
+    assert serialized_event.event_data == '{"attr1":"val1","attr2":"val2"}'
 
 
 @override_settings(DJANGOEVENTS_CONFIG={
@@ -69,7 +74,7 @@ def test_serializer_can_add_event_version_to_data():
         'ADDS_EVENT_VERSION_TO_DATA': True,
     },
 })
-def test_serializer_adds_event_version_to_data_when_settings_are_correct():
+def test_serializer_includes_schema_version_when_its_enabled():
     transcoder = UnifiedTranscoder(json_encoder_cls=DjangoJSONEncoder)
     event = SampleAggregate.Created(entity_id='b089a0a6-e0b3-480d-9382-c47f99103b3d', attr1='val1', attr2='val2')
     serialized_event = transcoder.serialize(event)

--- a/djangoevents/tests/test_unifiedtranscoder.py
+++ b/djangoevents/tests/test_unifiedtranscoder.py
@@ -58,9 +58,7 @@ def test_serialize_and_deserialize_2():
 
 
 @override_settings(DJANGOEVENTS_CONFIG={
-    'EVENT_TRANSCODER': {
-        'ADDS_EVENT_VERSION_TO_DATA': False,
-    },
+    'ADDS_SCHEMA_VERSION_TO_EVENT_DATA': False,
 })
 def test_serializer_doesnt_include_schema_version_when_its_disabled():
     transcoder = UnifiedTranscoder(json_encoder_cls=DjangoJSONEncoder)
@@ -70,9 +68,7 @@ def test_serializer_doesnt_include_schema_version_when_its_disabled():
 
 
 @override_settings(DJANGOEVENTS_CONFIG={
-    'EVENT_TRANSCODER': {
-        'ADDS_EVENT_VERSION_TO_DATA': True,
-    },
+    'ADDS_SCHEMA_VERSION_TO_EVENT_DATA': True,
 })
 def test_serializer_includes_schema_version_when_its_enabled():
     transcoder = UnifiedTranscoder(json_encoder_cls=DjangoJSONEncoder)

--- a/djangoevents/tests/test_unifiedtranscoder.py
+++ b/djangoevents/tests/test_unifiedtranscoder.py
@@ -58,7 +58,7 @@ def test_serialize_and_deserialize_2():
 
 
 def test_serializer_can_add_event_version_to_data():
-    transcoder = UnifiedTranscoder(json_encoder_cls=DjangoJSONEncoder, adds_event_version_to_data=True)
+    transcoder = UnifiedTranscoder(json_encoder_cls=DjangoJSONEncoder)
     event = SampleAggregate.Created(entity_id='b089a0a6-e0b3-480d-9382-c47f99103b3d', attr1='val1', attr2='val2')
     serialized_event = transcoder.serialize(event)
     assert serialized_event.event_data == '{"attr1":"val1","attr2":"val2","schema_version":1}'

--- a/djangoevents/unifiedtranscoder.py
+++ b/djangoevents/unifiedtranscoder.py
@@ -1,4 +1,3 @@
-from . import settings
 from .domain import DomainEvent
 from .schema import get_event_version
 from .utils import camel_case_to_snake_case
@@ -33,15 +32,9 @@ UnifiedStoredEvent = namedtuple('UnifiedStoredEvent', [
 
 
 class UnifiedTranscoder(AbstractTranscoder):
-    def __init__(self, json_encoder_cls=None, adds_event_version_to_data=None):
+    def __init__(self, json_encoder_cls=None):
         self.json_encoder_cls = json_encoder_cls
         # encrypt not implemented
-
-        # get default from settings
-        if adds_event_version_to_data is None:
-            adds_event_version_to_data = settings.transcoder_adds_event_version_to_data()
-
-        self.adds_event_version_to_data = adds_event_version_to_data
 
     def serialize(self, domain_event):
         """
@@ -56,11 +49,8 @@ class UnifiedTranscoder(AbstractTranscoder):
             'metadata',
         }}
 
-        event_version = get_event_version(domain_event.__class__)
-        if self.adds_event_version_to_data:
-            event_data['schema_version'] = event_version
-
         domain_event_class = type(domain_event)
+        event_version = get_event_version(domain_event_class)
 
         return UnifiedStoredEvent(
             event_id=domain_event.domain_event_id,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ class ReleaseToPyPICommand(upload):
 
 setup(
     name='djangoevents',
-    version='0.13.0',
+    version='0.13.1',
     url='https://github.com/ApplauseOSS/djangoevents',
     license='MIT',
     description='Building blocks for building Event Sourcing Django applications.',


### PR DESCRIPTION
I think the `CHANGELOG` sums it well. 😉 Previously I was adding `schema_version` only to transcoded events. Validation happens before transcoding, so events with `schema_version` in their Avro schemas didn't pass validation. To fix this I started adding `schema_version` to event objects using some light monkey patching. 🙈 

I changed the setting name in a backwards incompatible way, but it's OK when the major version is 0. (And as far as I know nobody's started using the setting introduced in 0.13.0 (besides me)).